### PR TITLE
add redis caching to proxy

### DIFF
--- a/controllers/redis.js
+++ b/controllers/redis.js
@@ -1,0 +1,64 @@
+const redis = require("redis");
+const client = new redis.createClient();
+const { asyncHandler, ErrAPI } = require('./utils.js');
+const bottomRange = 9000000;
+const topRange = 9350000;
+
+// check connection
+client.on("ready", () => console.log('redis ready'));
+client.on("error", err => console.log(err));
+
+// give promise functionality to redis actions
+const promisify = fn => (...args) => new Promise((resolve, reject) => {
+  fn(...args, (err, data) => {
+    if (err) reject(err);
+    else resolve(data);
+  })
+});
+
+//promisify get, set and del. using hashes
+const getter = promisify(client.get.bind(client));
+const setter = promisify(client.set.bind(client));
+const deleter = promisify(client.del.bind(client));
+
+// check if path is within the given productId range for caching
+const inRange = (productId) => {
+  const parsed = parseInt(productId)
+  let check = bottomRange <= parsed && parsed <= topRange && !isNaN(parsed);
+  return check; // return all values as a tuple
+}
+
+// path including productId used as key in order to differentiate all routes
+// check cache for a request
+exports.getCached = asyncHandler( async (req, res, next) => {
+  // check if  value exists in cache and send if it does
+  const { path, params: { productId } } = req;
+  let cachedResult;
+  let cacheIt = inRange(productId);
+  if (cacheIt) {
+    cachedResult = JSON.parse(await getter(path));
+  }
+
+  // if was in range and cache returned result
+  if(cacheIt && cachedResult !== null) {
+    res.json({cachedResult});
+  } 
+  // else continue and it will be added in getter
+  else next();
+});
+
+// function used in endpoints to set results to cache
+exports.setCache = async ( path, productId, value) => {
+  const cacheIt = inRange(productId);
+  if(cacheIt) {
+    await setter(path, value).catch(err => { throw err });
+  }
+};
+
+// remove a key from cache if underylying data is updated or deleted
+exports.invalidateKey = async (path, productId) => {
+  const invalidateIt = inRange(productId);
+  if(invalidateIt) {
+    await deleter(path).catch(err => { throw err });
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -373,6 +373,11 @@
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1070,6 +1075,35 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "redis": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.0.tgz",
+      "integrity": "sha512-//lAOcEtNIKk2ekZibes5oyWKYUVWMvMB71lyD/hS9KRePNkB7AU3nXGkArX6uDKEb2N23EyJBthAv6pagD0uw==",
+      "requires": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "registry-auth-token": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "axios": "^0.21.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "redis": "^3.1.0"
   },
   "devDependencies": {
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",

--- a/routers/description.js
+++ b/routers/description.js
@@ -1,11 +1,12 @@
 const { forwardingController } = require('../controllers/forwarding.js');
 const { asyncHandler } = require('../controllers/utils.js');
 const router = require('express').Router();
+const { getCached } = require('../controllers/redis.js');
 
 
 // router for requests to description service
 router.route('/description/:productId')
-  .get(asyncHandler(forwardingController('DESCRIPTION', 4004)))
+  .get(getCached, asyncHandler(forwardingController('DESCRIPTION', 4004)))
   .put(asyncHandler(forwardingController('DESCRIPTION', 4004)))
   .delete(asyncHandler(forwardingController('DESCRIPTION', 4004)));
 router.route('/descriptions/new')


### PR DESCRIPTION
## Trello
https://trello.com/c/aj45KkKq/12-refactor-proxy-to-forward-requests-and-split-prod-dev-environments

## Major Additions
`controllers/redis.js` - cache getter middleware and helper functions for getting, setting, and invalidating cache entries

## Purpose of PR
introduce caching to proxy in order to improve load tolerance